### PR TITLE
Reduce datapoints stored for datasets

### DIFF
--- a/django_publicdb/status_display/templatetags/fix_data.py
+++ b/django_publicdb/status_display/templatetags/fix_data.py
@@ -44,10 +44,16 @@ def fix_timestamps_in_data(values):
 
 @register.filter
 def slice_data(values, arg):
-    """Get every nth value from the list"""
+    """Get every nth value from the list
 
-    return values[::arg]
+    Note: This only slices data if the data has at least 1000 elements.
+    This to prevent the new shrunken datasets (~576 long) to be sliced.
 
+    """
+    if len(values) > 1000:
+        return values[::arg]
+    else:
+        return values
 
 @register.filter
 def round_data(values, arg):


### PR DESCRIPTION
Up to now all points were stored for the barometer/temperature datasets.
Since these are measured every 5 seconds there are 17280 points per day.
This takes up a lot of space, and if already sliced for display on the site.
Currently the datasets take 1.4 GB in the publicdb, the histograms only 360 MB.
However, there are far more histograms.
This should reduce the storage size (by factor ~30) and not affect the display.
It will affect the data you get when you press the Source button,
since this function only returns the data in the database.
However, those wanting the full dataset can use the Download form.

I tried to be as fair as possible, an average value or interpolation can cause problems in some cases, so I opted for a sampling method. Sample the full dataset every interval (150 seconds). So get the first value following a gap of at least 150 s between each value..
