### PR TITLE
Add new main page

### DIFF
--- a/django_publicdb/default/static/styles/base.css
+++ b/django_publicdb/default/static/styles/base.css
@@ -29,3 +29,6 @@ a {
 
 .small {
     font-size: 10pt;}
+
+h4 {
+    margin-bottom: 1em;}

--- a/django_publicdb/default/templates/index.html
+++ b/django_publicdb/default/templates/index.html
@@ -1,0 +1,46 @@
+{% extends 'base.html' %}
+
+{% load url from future %}
+
+{% block title %}HiSPARC Public Database{% endblock %}
+
+{% block content %}
+
+<div id="header">
+    <h2>HiSPARC Data</h2>
+</div>
+
+<p>
+    Choose one of the following pages to work with HiSPARC data.
+</p>
+
+<a href="{% url 'status_display.views.stations' %}"><h4>Data summaries and station status</h4></a>
+
+<p class="small">
+    This section shows daily data summaries and the current status for
+    all stations.
+</p>
+
+<a href="{% url 'status_display.views.stations_on_map' %}"><h4>Stations on a map</h4></a>
+
+<p class="small">
+    A nice overview of all stations on a map.
+</p>
+
+<a href="{% url 'raw_data.views.download_form' %}"><h4>Download data</h4></a>
+
+<p class="small">
+    Download HiSPARC data as csv files which can be imported by various
+    programs (e.g. Excel and Python).
+</p>
+
+<a href="{{ MEDIA_URL }}jsparc/"><h4>jSparc</h4></a>
+
+<p class="small">
+    Web-based tools to work with the detected data and metadata. Data is
+    loaded in the browser and can then be used to create graphs or used
+    in analysis.
+</p>
+
+    
+{% endblock %}

--- a/django_publicdb/default/views.py
+++ b/django_publicdb/default/views.py
@@ -1,0 +1,8 @@
+from django.shortcuts import render_to_response
+from django.template import RequestContext
+
+
+def index(request):
+    """Show the static index page"""
+    return render_to_response('index.html',
+                              context_instance=RequestContext(request))

--- a/django_publicdb/urls.py
+++ b/django_publicdb/urls.py
@@ -8,7 +8,7 @@ from django.contrib import admin
 admin.autodiscover()
 
 urlpatterns = patterns('',
-    (r'^$', RedirectView.as_view(url='show/stations', permanent=False)),
+    (r'^$', 'django_publicdb.default.views.index'),
 
     (r'^robots\.txt$', TemplateView.as_view(template_name='robots.txt',
                                             content_type='text/plain')),


### PR DESCRIPTION
New index page for the data.hisparc.nl page.
This should be used to refer users to the right page
- status/summaries
- jsparc data analysis
- data download forms
- sapphire data analysis
- ... etc.. HiSPARC data stuff..

Perhaps add some images like http://www.hisparc.nl/hisparc-data/
Do we also link to subpages of jSparc?

We now have multiple 'link'-pages. Perhaps some need to be consilidated..
http://docs.hisparc.nl/
http://data.hisparc.nl/media/jsparc/
http://www.hisparc.nl/hisparc-data/
http://www.hisparc.nl/downloads/software/
(todo) http://data.hisparc.nl/
