### PR TITLE
Add aliases and PS1 to bashrc in provisioning

### DIFF
--- a/provisioning/publicdb.yml
+++ b/provisioning/publicdb.yml
@@ -49,6 +49,26 @@
   command: /srv/publicdb/publicdb_env/bin/pip install
            -r /home/{{ ansible_user_id }}/pip.list
 
+- name: Add conda env alias to bashrc
+  lineinfile: dest=~/.bashrc
+              regex="^alias envpub"
+              line="alias envpub='source activate /srv/publicdb/publicdb_env'"
+
+- name: Add publicdb cd alias to bashrc
+  lineinfile: dest=~/.bashrc
+              regex="^alias cdpub"
+              line="alias cdpub='cd /srv/publicdb/www'"
+
+- name: Add alias to update publicdb in bashrc
+  lineinfile: dest=~/.bashrc
+              regex="^alias uppub"
+              line="alias uppub='cdpub && envpub && git fetch && git reset --hard origin/master && touch /tmp/uwsgi-reload.me'"
+
+- name: Change PS1 in bashrc
+  lineinfile: dest=~/.bashrc
+              regex="PS1="
+              line="[[ -n \"$SSH_CLIENT\" ]] && PS1='\[\e[1;30m\]$(date +%y%m%d\ %H:%M:%S) \[\e[1;32m\]\u@\h \[\e[1;34m\]\w\n$CONDA_DEFAULT_ENV\[\e[m\]> '"
+
 - name: set up MySQL database
   mysql_db: name=publicdb state=present
 


### PR DESCRIPTION
I added some useful aliases also used in production to the provisioning to ensure they are alway available.

Since I do not have a working veewee/vagrant box I can not currently test this.

@jorianvo Can you please verify that these additions work as expected? (that the lines are added to the bashrc).