### PR TITLE
Move generatorstate initial data to separate json

### DIFF
--- a/django_publicdb/histograms/fixtures/initial_data.json
+++ b/django_publicdb/histograms/fixtures/initial_data.json
@@ -80,15 +80,5 @@
         "name": "Barometer",
         "slug": "barometer"
     }
-},
-{
-    "pk": 1,
-    "model": "histograms.generatorstate",
-    "fields": {
-        "check_is_running": false,
-        "update_last_run": "1970-01-01 00:00:00",
-        "update_is_running": false,
-        "check_last_run": "1970-01-01 00:00:00"
-    }
 }
 ]

--- a/django_publicdb/histograms/fixtures/initial_generator_state.json
+++ b/django_publicdb/histograms/fixtures/initial_generator_state.json
@@ -1,0 +1,12 @@
+[
+{
+    "pk": 1,
+    "model": "histograms.generatorstate",
+    "fields": {
+        "check_is_running": false,
+        "update_last_run": "1970-01-01 00:00:00",
+        "update_is_running": false,
+        "check_last_run": "1970-01-01 00:00:00"
+    }
+}
+]

--- a/provisioning/fake_datastore.yml
+++ b/provisioning/fake_datastore.yml
@@ -6,3 +6,7 @@
   file: path=/databases/frome state=directory
         owner=hisparc group=hisparc mode=2775
   sudo: yes
+
+- name: load initial generator state
+  command: chdir=/srv/publicdb/www/django_publicdb
+           /srv/publicdb/publicdb_env/bin/python manage.py loaddata initial_generator_state.json


### PR DESCRIPTION
A fix for #87

Only 'initial_data.[...]' files are loaded during syncdb.
So moving the generatorstate data to a separate file keeps it from
being loaded during syncdb.
It is loaded separately for the vagant host to ensure it exists for that host.
