### PR TITLE
Remove matplotlib from provisioning

### DIFF
--- a/provisioning/conda.list
+++ b/provisioning/conda.list
@@ -2,5 +2,4 @@ pip
 ipython
 pytables
 scipy
-matplotlib
 mysql-python


### PR DESCRIPTION
This package is no longer required by SAPPHiRE and the publicdb.
The latest version of SAPPHiRE removed the matplotlib (pylab) import from the find_mpv module.
No reference to matplotlib/pylab was found in any Python script in the publicdb code.
So the matplotlib package should not be a requirement anymore.

It might be a useful package to have, to make some plots on the server.. but not required.