### PR TITLE
Eventtime csv

### DIFF
--- a/django_publicdb/api/views.py
+++ b/django_publicdb/api/views.py
@@ -127,7 +127,7 @@ def station(request, station_number, year=None, month=None, day=None):
                       'beta': layout.detector_1_beta,
                       'mpv': mpv_fits[0]}]
     scintillators.append({'radius': layout.detector_2_radius,
-                          'alpha': layout.detector_alpha,
+                          'alpha': layout.detector_2_alpha,
                           'height': layout.detector_2_height,
                           'beta': layout.detector_2_beta,
                           'mpv': mpv_fits[1]})

--- a/django_publicdb/histograms/esd.py
+++ b/django_publicdb/histograms/esd.py
@@ -12,7 +12,7 @@ from sapphire.analysis import process_events, coincidences, calibration
 from sapphire import clusters
 
 from ..inforecords.models import Station
-import datastore
+from . import datastore
 
 from django.conf import settings
 

--- a/django_publicdb/histograms/fit_pulseheight_peak.py
+++ b/django_publicdb/histograms/fit_pulseheight_peak.py
@@ -9,8 +9,8 @@ import scipy
 import scipy.optimize
 import scipy.stats
 
-from models import Configuration, PulseheightFit
-import esd
+from .models import Configuration, PulseheightFit
+from . import esd
 
 
 logger = logging.getLogger('histograms.fit_pulseheight_peak')

--- a/django_publicdb/inforecords/models.py
+++ b/django_publicdb/inforecords/models.py
@@ -308,7 +308,7 @@ class DetectorHisparc(models.Model):
     class Meta:
         unique_together = [('station', 'startdate')]
         verbose_name_plural = 'Detector HiSPARC'
-        ordering = ('station__number',)
+        ordering = ('station',)
 
 
 class ElectronicsType(models.Model):

--- a/django_publicdb/raw_data/date_generator.py
+++ b/django_publicdb/raw_data/date_generator.py
@@ -7,10 +7,10 @@ def daterange(start, stop):
     This is a generator for date ranges. Based on a start and stop value,
     it generates one day intervals.
 
-    :param start: a date instance
-    :param stop: a date instance
+    :param start: a date instance, end of range
+    :param stop: a date instance, end of range
+    :yield date: dates with one day interval between start and stop
 
-    :yield date: one day intervals between start and stop
     """
     if start == stop:
         yield start
@@ -22,3 +22,27 @@ def daterange(start, stop):
             cur += datetime.timedelta(days=1)
             yield cur
         return
+
+
+def single_day_ranges(start, end):
+    """Generate datetime ranges consisting of a single day.
+
+    Generate datetime ranges, a single day at a time.  The generator keeps
+    returning two datetime values, making up a range of a full day.
+    However, the first and last days may be shorter, if a specific
+    time-of-day was specified.
+
+    :param start: a datetime instance, start of range
+    :param end: a datetime instance, end of range
+    :yield cur,next: date intervals between start and stop
+
+    """
+    cur = start
+    next_day = (cur.replace(hour=0, minute=0, second=0, microsecond=0) +
+                datetime.timedelta(days=1))
+
+    while next_day < end:
+        yield cur, next_day
+        cur = next_day
+        next_day = cur + datetime.timedelta(days=1)
+    yield cur, end

--- a/django_publicdb/raw_data/views.py
+++ b/django_publicdb/raw_data/views.py
@@ -21,9 +21,9 @@ from sapphire.analysis.coincidence_queries import CoincidenceQuery
 from ..inforecords.models import Station, Cluster
 from ..histograms.models import Summary, NetworkSummary
 from ..histograms import esd
-from ..raw_data.forms import DataDownloadForm, CoincidenceDownloadForm
-
-import knmi_lightning
+from .forms import DataDownloadForm, CoincidenceDownloadForm
+from .date_generator import single_day_ranges
+from . import knmi_lightning
 
 from SimpleXMLRPCServer import SimpleXMLRPCDispatcher
 dispatcher = SimpleXMLRPCDispatcher()
@@ -663,29 +663,6 @@ def prettyprint_timerange(t0, t1):
 
     timerange = timerange.replace('-', '').replace(' ', '_').replace(':', '')
     return timerange
-
-
-def single_day_ranges(start, end):
-    """Generate datetime ranges consisting of a single day.
-
-    Generate datetime ranges, a single day at a time.  The generator keeps
-    returning two datetime values, making up a range of a full day.
-    However, the first and last days may be shorter, if a specific
-    time-of-day was specified.
-
-    :param start: start of range
-    :param end: end of range
-
-    """
-    cur = start
-    next_day = (cur.replace(hour=0, minute=0, second=0, microsecond=0) +
-                datetime.timedelta(days=1))
-
-    while next_day < end:
-        yield cur, next_day
-        cur = next_day
-        next_day = cur + datetime.timedelta(days=1)
-    yield cur, end
 
 
 def get_lightning_path(date):

--- a/django_publicdb/status_display/templates/source_eventtime.csv
+++ b/django_publicdb/status_display/templates/source_eventtime.csv
@@ -1,0 +1,21 @@
+# HiSPARC eventtime source
+#
+# Station: {{ station_number }}
+# Data taken from {{ start|date:"Y-m-d H:00:00" }} to {{ end|date:"Y-m-d H:00:00" }}
+#
+# HiSPARC data is licensed under Creative Commons Attribution-ShareAlike 4.0.
+#
+#
+# Please note: the 'timestamp' is the left bin edge. The width of each bin
+# is 1 hour, i.e. 3600 seconds. Value means the number of events which were
+# measured during 1 hour.
+#
+# This data contains the following columns:
+#
+# timestamp: start of hour [UNIX timestamp]
+# value:     number of events [counts]
+#
+#
+# timestamp	value
+{% for row in data %}{{ row.0 }}	{{ row.1 }}
+{% endfor %}

--- a/django_publicdb/status_display/templates/source_eventtime.csv
+++ b/django_publicdb/status_display/templates/source_eventtime.csv
@@ -1,7 +1,7 @@
 # HiSPARC eventtime source
 #
 # Station: {{ station_number }}
-# Data taken from {{ start|date:"Y-m-d H:00:00" }} to {{ end|date:"Y-m-d H:00:00" }}
+# Data taken from {{ start|date:"Y-m-d" }} to {{ end|date:"Y-m-d" }}
 #
 # HiSPARC data is licensed under Creative Commons Attribution-ShareAlike 4.0.
 #

--- a/django_publicdb/status_display/urls.py
+++ b/django_publicdb/status_display/urls.py
@@ -22,6 +22,7 @@ urlpatterns = patterns('django_publicdb.status_display.views',
     (r'^source/coincidencetime/(?P<year>\d{4})/(?P<month>\d+)/(?P<day>\d+)/$', 'get_coincidencetime_histogram_source'),
     (r'^source/coincidencenumber/(?P<year>\d{4})/(?P<month>\d+)/(?P<day>\d+)/$', 'get_coincidencenumber_histogram_source'),
 
+    (r'^source/eventtime/(?P<station_number>\d+)/$', 'get_eventtime_source'),
     (r'^source/eventtime/(?P<station_number>\d+)/(?P<year>\d{4})/(?P<month>\d+)/(?P<day>\d+)/$', 'get_eventtime_histogram_source'),
     (r'^source/pulseheight/(?P<station_number>\d+)/(?P<year>\d{4})/(?P<month>\d+)/(?P<day>\d+)/$', 'get_pulseheight_histogram_source'),
     (r'^source/pulseintegral/(?P<station_number>\d+)/(?P<year>\d{4})/(?P<month>\d+)/(?P<day>\d+)/$', 'get_pulseintegral_histogram_source'),

--- a/django_publicdb/status_display/views.py
+++ b/django_publicdb/status_display/views.py
@@ -554,7 +554,7 @@ def get_eventtime_source(request, station_number, start=None, end=None):
         # Get first date with data
         start = Summary.objects.filter(station__number=station_number,
                                        date__gte=FIRSTDATE, date__lt=end,
-                                       num_events__isnull=False).first()
+                                       num_events__isnull=False).first().date
 
     data = get_eventtime_histogram_sources(station_number, start, end)
     response = render(request, 'source_eventtime.csv',

--- a/django_publicdb/status_display/views.py
+++ b/django_publicdb/status_display/views.py
@@ -14,7 +14,7 @@ from ..histograms.models import (DailyHistogram, DailyDataset, Configuration,
 from ..inforecords.models import (Pc, Station, Cluster, Country,
                                   DetectorHisparc)
 from ..station_layout.models import StationLayout
-from nagios import status_lists, get_status_counts, get_station_status
+from .nagios import status_lists, get_status_counts, get_station_status
 
 
 FIRSTDATE = datetime.date(2002, 1, 1)

--- a/django_publicdb/status_display/views.py
+++ b/django_publicdb/status_display/views.py
@@ -5,6 +5,7 @@ from django.db.models import Q
 
 from collections import OrderedDict
 from operator import itemgetter
+from itertools import izip
 import calendar
 import datetime
 
@@ -594,7 +595,7 @@ def get_eventtime_histogram_sources(station_number, start, end):
                 break
         else:
             values.extend(no_data)
-    return zip(bins, values)
+    return izip(bins, values)
 
 
 def get_pulseheight_histogram_source(request, station_number, year, month,

--- a/django_publicdb/status_display/views.py
+++ b/django_publicdb/status_display/views.py
@@ -549,7 +549,11 @@ def get_eventtime_source(request, station_number, start=None, end=None):
     """Get all eventtime data from start to end"""
 
     if end is None:
-        end = datetime.date.today()
+        today = datetime.date.today()
+        last = Summary.objects.filter(station__number=station_number,
+                                      date__gte=FIRSTDATE, date__lt=today,
+                                      num_events__isnull=False).last().date
+        end = last + datetime.timedelta(days=1)
     if start is None:
         # Get first date with data
         start = Summary.objects.filter(station__number=station_number,


### PR DESCRIPTION
Add eventtime csv from start of station activity until today.
This gives a simple overview of when the station was active.

Todo;
- [x] Improved error handling
    - Validate station number
    - Station without any events
- Allow request specific start/end date
- ..