### PR TITLE
Improve ESD download speed

### DIFF
--- a/django_publicdb/raw_data/views.py
+++ b/django_publicdb/raw_data/views.py
@@ -16,7 +16,7 @@ import urllib
 from cStringIO import StringIO
 
 import dateutil.parser
-from numpy import column_stack, where, degrees, isnan, char
+from numpy import column_stack, where, degrees, isnan, char, empty
 
 from sapphire.analysis.coincidence_queries import CoincidenceQuery
 
@@ -753,7 +753,7 @@ class FakeReconstructionsTable(object):
 
     def __getitem__(self, key):
         if len(key):
-            arr = np.empty(len(key))
+            arr = empty(len(key))
             arr.fill(-999)
             return {'zenith': arr, 'azimuth': arr}
 

--- a/django_publicdb/raw_data/views.py
+++ b/django_publicdb/raw_data/views.py
@@ -408,7 +408,7 @@ def get_weather_from_esd_in_range(station, start, end):
                         '(ts0 <= timestamp) & (timestamp < ts1)')
         except (IOError, tables.NoSuchNodeError):
             continue
-        except:
+        else:
             yield events
 
 

--- a/django_publicdb/raw_data/views.py
+++ b/django_publicdb/raw_data/views.py
@@ -324,7 +324,7 @@ def get_events_from_esd_in_range(station, start, end):
                     reconstructions_table = station_node.reconstructions
                 except tables.NoSuchNodeError:
                     reconstructions_table = FakeReconstructionsTable()
-                if (end - start).days == 1:
+                if (t1 - t0).days == 1:
                     events = events_table.read()
                     reconstructions = reconstructions_table[events['event_id']]
                 else:
@@ -399,7 +399,7 @@ def get_weather_from_esd_in_range(station, start, end):
         try:
             with tables.open_file(filepath) as f:
                 station_node = esd.get_station_node(f, station)
-                if (end - start).days == 1:
+                if (t1 - t0).days == 1:
                     events = station_node.weather.read()
                 else:
                     ts0 = calendar.timegm(t0.utctimetuple())

--- a/django_publicdb/raw_data/views.py
+++ b/django_publicdb/raw_data/views.py
@@ -677,8 +677,14 @@ def get_coincidence_events(f, coincidence):
 
 
 def clean_float_array(numbers, precision=5):
-    """Format floating point numbers for data download."""
+    """Format floating point numbers for data download.
 
+    :param numbers: array like list of values
+    :param precision: the number of significant numbers, this includes
+                      numbers to the left of the decimal. Must be 3 or higher,
+                      to support -999.
+
+    """
     if precision < 3:
         # Unable to preserve -999 if precision less than 3.
         precision = 3


### PR DESCRIPTION
Yield ESD data in chunks per day (not longer to prevent complicated things and memory usage).
Improve ESD download speed by using Numpy arrays magic.

- Skips table query if the entire day is requested
- Use Numpy arrays

Takes a little longer to get up to speed, but much faster overall. `>> 1MB/s`

Todo:

- [x] Test downloading data
    - [x] With reconstructions
        - [x] One day
        - [x] Part of day
        - [x] Multiple days
    - [x] Without reconstructions
        - [x] One day
        - [x] Part of day
        - [x] Multiple days
- [x] Download with SAPPHiRE
- [x] Weather
