### PR TITLE
Rename rchi2 to error

### DIFF
--- a/django_publicdb/histograms/esd.py
+++ b/django_publicdb/histograms/esd.py
@@ -10,11 +10,11 @@ import numpy as np
 import tables
 
 from sapphire import (determine_detector_timing_offsets,
+                      DetermineStationTimingOffsets,
                       ProcessEventsFromSourceWithTriggerOffset,
                       ProcessWeatherFromSource, CoincidencesESD,
                       ReconstructESDEventsFromSource, ProcessTimeDeltas)
-from sapphire.analysis.calibration import (DetermineStationTimingOffsets,
-                                           datetime_range)
+from sapphire.analysis.calibration import datetime_range
 
 from ..inforecords.models import Station
 from .models import DetectorTimingOffset

--- a/django_publicdb/histograms/jobs.py
+++ b/django_publicdb/histograms/jobs.py
@@ -569,13 +569,13 @@ def update_station_timing_offsets(network_summary):
             if date in cuts:
                 logger.debug("Setting offset for config cut to nan for %s"
                              " ref %s at %s" % (summary, ref_summary, date))
-                offset, rchi2 = np.nan, np.nan
+                offset, error = np.nan, np.nan
             else:
                 logger.debug("Determining station offset for %s"
                              " ref %s at %s" % (summary, ref_summary, date))
-                offset, rchi2 = off.determine_station_timing_offset(date, sn,
+                offset, error = off.determine_station_timing_offset(date, sn,
                                                                     ref_sn)
-            save_station_offset(ref_summary, summary, offset, rchi2)
+            save_station_offset(ref_summary, summary, offset, error)
 
 
 def update_zenith_histogram(summary, tempfile_path, node_path):
@@ -750,13 +750,13 @@ def save_offsets(summary, offsets):
     logger.debug("Saved succesfully")
 
 
-def save_station_offset(ref_summary, summary, offset, rchi2):
+def save_station_offset(ref_summary, summary, offset, error):
     """Store the station timing offset in database
 
     :param summary: summary of station (station and date)
     :param ref_summary: summary of reference station (station and date)
     :param offset: station timing offset
-    :param rchi2: reduced chi squared parameter of the fit
+    :param error: error of the offset
 
     """
     logger.debug("Saving station offset for %s ref %s" % (summary,
@@ -764,10 +764,10 @@ def save_station_offset(ref_summary, summary, offset, rchi2):
     field = {}
     if not np.isnan(offset):
         field['offset'] = round(offset, 1)
-        field['rchi2'] = round(rchi2, 2)
+        field['error'] = round(error, 2)
     else:
         field['offset'] = None
-        field['rchi2'] = None
+        field['error'] = None
 
     StationTimingOffset.objects.update_or_create(source=summary,
                                                  ref_source=ref_summary,

--- a/django_publicdb/histograms/migrations/0008_rename_rchi2_to_error.py
+++ b/django_publicdb/histograms/migrations/0008_rename_rchi2_to_error.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('histograms', '0007_unique_stationtimingoffset'),
+    ]
+
+    operations = [
+        migrations.RenameField('StationTimingOffset', 'rchi2', 'error'),
+    ]

--- a/django_publicdb/histograms/models.py
+++ b/django_publicdb/histograms/models.py
@@ -402,7 +402,7 @@ class StationTimingOffset(models.Model):
     ref_source = models.ForeignKey('Summary', related_name='ref_source')
     source = models.ForeignKey('Summary', related_name='source')
     offset = models.FloatField(blank=True, null=True)
-    rchi2 = models.FloatField(blank=True, null=True)
+    error = models.FloatField(blank=True, null=True)
 
     def clean(self):
         if self.ref_source.station == self.source.station:

--- a/django_publicdb/status_display/templates/source_station_timing_offsets.tsv
+++ b/django_publicdb/status_display/templates/source_station_timing_offsets.tsv
@@ -9,8 +9,8 @@
 #
 # timestamp: time of offset calibration in seconds after 1970-1-1 [UNIX timestamp]
 # offset:    station timing offsets [ns]
-# rchi2:     reduced chi squared
+# error:     offset errors [ns]
 #
 #
-# timestamp	offset	rchi2
+# timestamp	offset	error
 {{ tsvdata }}

--- a/django_publicdb/status_display/views.py
+++ b/django_publicdb/status_display/views.py
@@ -994,7 +994,7 @@ def get_station_timing_offsets(ref_station_number, station_number):
         source__date__gte=FIRSTDATE,
         source__date__lte=datetime.date.today())
 
-    data = offsets.values_list('source__date', 'offset', 'rchi2')
+    data = offsets.values_list('source__date', 'offset', 'error')
     return data
 
 

--- a/provisioning/pip.list
+++ b/provisioning/pip.list
@@ -5,4 +5,4 @@ Django>=1.7,<1.8
 recaptcha-client
 python-dateutil
 
-hisparc-sapphire>=0.14,<0.15
+hisparc-sapphire>=0.15,<0.16


### PR DESCRIPTION
Use standard error of the mean instead of rchi2.
Update in code, models (with migration), and tsv.