### PR TITLE
Prevent escapeing of password in datastore cfg

### DIFF
--- a/django_publicdb/inforecords/templates/datastore.cfg
+++ b/django_publicdb/inforecords/templates/datastore.cfg
@@ -1,2 +1,2 @@
-{% for station in stations %}{{ station.number }},{{ station.cluster.main_cluster }},{{ station.password }}
+{% for station in stations %}{{ station.number }},{{ station.cluster.main_cluster }},{{ station.password|safe }}
 {% endfor %}


### PR DESCRIPTION
Django escapes all data that is rendered in templates. `&` -> `&amp;`.
This is to prevent script insertion attacks. However, as we send the
datastore cfg as `text\plain` to the datastore, which just saves the
datastream to disk, we are not vulnerable to script insertion.

Mark the password field as safe, to prevent character escaping.

Fixes gh-164.