### PR TITLE
Ansible_local on windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -214,10 +214,7 @@ Now add the VM::
 
    $ vagrant up publicdb
 
-Provisioning might stop if the kernel of the guest VM is upgraded, becaue
+Provisioning might stop if the kernel of the guest VM is upgraded, because
 this will trigger a reboot. Reload and restart provisioning::
 
    $ vagrant reload publicdb --provision
-
-The publicdb and datastore VMs build succesfully using ansible_local.
-Provisioning of the vpn VM is currently not possible using Windows.

--- a/README.rst
+++ b/README.rst
@@ -194,28 +194,30 @@ If you want to provision all servers at once, you can leave off the ``-l`` optio
 Provisioning using a Windows host
 ---------------------------------
 
-Ansible does not support windows as a host (control machine). By using the ``ansible_local`` provisioner, setting up
-a test VM on Windows is possible.
+Ansible does not support windows as a host (control machine). On Windows
+the ``ansible_local`` provisioner is used.
 
-All scripts that are passed to ``/bin/bash`` on the target CentOS6 machine will fail miserably when carriage returns
-(CR, ^M, 0x0D) are present. This will cause all sorts of strange, hard to track down, errors. Make sure all files have
-unix-like line-endings (LF not CRLF)::
+All scripts that are passed to ``/bin/bash`` on the target CentOS6 machine
+will fail miserably when carriage returns (CR, ^M, 0x0D) are present. This
+will cause all sorts of strange, hard to track down, errors. Make sure all
+files have unix-like line-endings (LF not CRLF)::
 
    $ git config --global core.autocrlf "input"
    $ git clone git@github.com:HiSPARC/publicdb.git
 
-Check ``packer/CentOS6/http/ks.cfg`` and ``provisioning/*sh`` for carriage returns. 
+Check ``packer/CentOS6/http/ks.cfg`` and ``provisioning/*sh`` for carriage
+returns.
 
 Build the base box using packer.
-
-Change provisioner ``ansible`` to ``ansible_local`` in ``Vagrantfile``. Move ``host_key_checking = False`` to ``ansible.cfg``.
-Change the ``publicdb`` line in ``provisioning ansible_inventory`` to ``publicdb ansible_connection=local``. 
 
 Now add the VM::
 
    $ vagrant up publicdb
-   
-Provisioning will stop at the reboot after upgrading packages. Edit ``common.yml`` to start after the reboot
-(remove everything above the reboot step) and::
 
-   $ vagrant up publicdb --provision
+Provisioning might stop if the kernel of the guest VM is upgraded, becaue
+this will trigger a reboot. Reload and restart provisioning::
+
+   $ vagrant reload publicdb --provision
+
+The publicdb and datastore VMs build succesfully using ansible_local.
+Provisioning of the vpn VM is currently not possible using Windows.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,10 +49,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
   end
 
-  config.vm.provision :ansible do |ansible|
-    ansible.inventory_path = "provisioning/ansible_inventory"
-    ansible.playbook = "provisioning/playbook.yml"
-    ansible.host_key_checking = false
+  if Vagrant::Util::Platform.windows? then
+      provisioner = :ansible_local
+      inventory_path = "provisioning/ansible_inventory_local"
+  else
+      provisioner = :ansible
+      inventory_path = "provisioning/ansible_inventory"
   end
+
+  config.vm.provision provisioner do |ansible|
+    ansible.inventory_path = inventory_path
+    ansible.playbook = "provisioning/playbook.yml"
+  end
+
   config.ssh.username = "hisparc"
 end

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 hostfile=provisioning/ansible_inventory
+host_key_checking=False
 
 [ssh_connection]
 pipelining=True

--- a/provisioning/ansible_inventory_local
+++ b/provisioning/ansible_inventory_local
@@ -1,0 +1,10 @@
+pique.nikhef.nl
+tietar.nikhef.nl
+
+vagrant ansible_connection=local
+publicdb ansible_connection=local
+vpn ansible_connection=local
+datastore ansible_connection=local
+
+[all:vars]
+ansible_ssh_user=hisparc

--- a/provisioning/ansible_inventory_local
+++ b/provisioning/ansible_inventory_local
@@ -1,7 +1,3 @@
-pique.nikhef.nl
-tietar.nikhef.nl
-
-vagrant ansible_connection=local
 publicdb ansible_connection=local
 vpn ansible_connection=local
 datastore ansible_connection=local


### PR DESCRIPTION
This modifies `Vagrantfile` to use the `ansible_local` provisioner on Windows, as ansible cannot use Windows as a host. I should not change Linux/Mac behaviour.

This builds `publicdb` and `datastore` successfully.

Unfortunately `vpn` breaks ansible_local when shorewall is activated in the middle of provisioning.

I'd like to have this in `master` to be able to more easily develop on windows without hacks.

ToDo:
 - [x] test on Mac/Linux. To make sure it does not break anything. (reviewers)