### PR TITLE
Provision the datastore for py3

### DIFF
--- a/provisioning/datastore-config-server.py
+++ b/provisioning/datastore-config-server.py
@@ -9,9 +9,9 @@
     library documentation and extended.
 
 """
-from SimpleXMLRPCServer import SimpleXMLRPCServer
-from SimpleXMLRPCServer import SimpleXMLRPCRequestHandler
-import urllib2
+from xmlrpc.server import SimpleXMLRPCServer
+from xmlrpc.server import SimpleXMLRPCRequestHandler
+import urllib.request, urllib.error, urllib.parse
 import hashlib
 import subprocess
 import os
@@ -24,7 +24,7 @@ RELOAD_PATH = '/tmp/uwsgi-reload.me'
 def reload_datastore():
     """Load datastore config and reload datastore, if necessary"""
 
-    datastore_cfg = urllib2.urlopen(CFG_URL).read()
+    datastore_cfg = urllib.request.urlopen(CFG_URL).read()
     new_hash = hashlib.sha1(datastore_cfg).hexdigest()
 
     try:

--- a/provisioning/datastore.yml
+++ b/provisioning/datastore.yml
@@ -35,7 +35,7 @@
 - name: create conda environment
   shell: creates=/srv/datastore/datastore_env
          yes | /opt/miniconda/bin/conda create
-         -p /srv/datastore/datastore_env python --yes
+         -p /srv/datastore/datastore_env python=3.6 --yes
 
 - name: install conda packages in conda environment
   command: /opt/miniconda/bin/conda install -p /srv/datastore/datastore_env


### PR DESCRIPTION
 - Create python 3.6 conda enviroment
 - 2to3 changes for `datastore-config-server.py`