### PR TITLE
Import SerializedDataField from histograms.

### DIFF
--- a/publicdb/coincidences/models.py
+++ b/publicdb/coincidences/models.py
@@ -7,76 +7,7 @@ import numpy as np
 import json
 
 from ..inforecords.models import Station
-
-
-class SerializedDataField(models.Field):
-
-    def db_type(self, connection):
-        return 'BYTEA'
-
-    # DB/Deserializer -> Python
-
-    def from_db_value(self, value, expression, connection, context):
-        return self.to_python(value)
-
-    def to_python(self, value):
-
-        # Couple possibilities:
-
-        # 1. If it is a list
-
-        if isinstance(value, list):
-            return value
-
-        if not isinstance(value, unicode) and not isinstance(value, str):
-            return []
-
-        # 2. If the value is somehow for whatever reason a JSON array formatted
-        #    string instead of a JSON array
-
-        if value[0] == '[' and value[-1] == ']':
-            return_value = json.loads(value)
-
-            if isinstance(return_value, list):
-                return return_value
-
-            return []
-
-        # 3. If the value is a base64 z-compressed pickled python list
-
-        try:
-            unpickled = pickle.loads(zlib.decompress(base64.b64decode(value)))
-        except pickle.PickleError:
-            return eval(value)
-        else:
-            if isinstance(unpickled, list):
-                data = []
-                for x in unpickled:
-                    if isinstance(x, np.ndarray):
-                        data.append(x.tolist())
-                    else:
-                        data.append(x)
-                return data
-            else:
-                return unpickled
-
-    # Python -> DB
-
-    def get_prep_value(self, value):
-        return base64.b64encode(zlib.compress(pickle.dumps(value)))
-
-    # Python -> Serializer
-
-    def value_to_string(self, obj):
-
-        human_readable_output = False
-
-        value = self._get_val_from_obj(obj)
-
-        if human_readable_output:
-            return value
-
-        return self.get_prep_value(value)
+from ..histograms.models import SerializedDataField
 
 
 class Event(models.Model):

--- a/publicdb/coincidences/models.py
+++ b/publicdb/coincidences/models.py
@@ -1,11 +1,5 @@
 from django.db import models
 
-import zlib
-import cPickle as pickle
-import base64
-import numpy as np
-import json
-
 from ..inforecords.models import Station
 from ..histograms.models import SerializedDataField
 


### PR DESCRIPTION
Fixes specific implementation of to_python() not being compatible with
postgress/BYTEA field.

Make it DRY.

This effectively reverts commit 311d7b8363721b7da563951ae84393c2e4ea5d48. Which implemented storing JSON fixtures in `SerializedDataFields`. As far as I can tell, this feature is unused.

As I cannot properly restore the database in my VM, I have not tested this fully. However, with this patch, I can read pulseheights, traces and integrals from Events (Coincidences) in the Django admin panel.

Fixes #193 
Fixes HiSPARC/jsparc#52