### PR TITLE
Update the local ansible on the guest VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,11 +33,11 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provision provisioner do |ansible|
-      if provisioner == "ansible_local" then
-        # force required upgrade of ansible on guest
-        ansible.install = true
-        ansible.version = "latest"
-      end
+    if provisioner == :ansible_local then
+      # force required upgrade of ansible on guest
+      ansible.install = true
+      ansible.version = "latest"
+    end
     ansible.compatibility_mode = "2.0"
     ansible.inventory_path = inventory_path
     ansible.playbook = "provisioning/playbook.yml"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,6 +33,11 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provision provisioner do |ansible|
+      if provisioner == "ansible_local" then
+        # force required upgrade of ansible on guest
+        ansible.install = true
+        ansible.version = "latest"
+      end
     ansible.compatibility_mode = "2.0"
     ansible.inventory_path = inventory_path
     ansible.playbook = "provisioning/playbook.yml"


### PR DESCRIPTION
To be able to use the ansible_local provisioner, ansible on the guest
VM will need to be updated to the latest version.

This fixes the issues I was having on Windows. (The `ansible_local` provisioner was using the default CentOS ansible 2.2.x on the guest VM). The recent ansible changes require ansible 2.4.