### PR TITLE
Exclude raw data XMLRPC from CSRF protection.

### DIFF
--- a/publicdb/raw_data/views.py
+++ b/publicdb/raw_data/views.py
@@ -20,6 +20,7 @@ from django.http import (HttpResponse, HttpResponseBadRequest,
                          HttpResponseRedirect, StreamingHttpResponse)
 from django.shortcuts import get_object_or_404, render
 from django.template import Context, loader
+from django.views.decorators.csrf import csrf_exempt
 
 from sapphire import CoincidenceQuery
 
@@ -45,6 +46,7 @@ class SingleLineStringIO:
         self.line = line
 
 
+@csrf_exempt
 def call_xmlrpc(request):
     """Dispatch XML-RPC requests."""
 


### PR DESCRIPTION
By default django blocks all POST requests without a valid CSRF token.
Add @csrf_exempt to the xmlrpc view to exclude.

Fixes #199 

See also: https://docs.djangoproject.com/en/2.0/ref/csrf/