### PR TITLE
Fix duplicates in QuerySets.

### DIFF
--- a/publicdb/analysissessions/models.py
+++ b/publicdb/analysissessions/models.py
@@ -161,7 +161,7 @@ class SessionRequest(models.Model):
 
         stations = []
         for station in Station.objects.filter(cluster=self.cluster,
-                                              pc__is_test=False):
+                                              pc__is_test=False).distinct():
             station_group_name = 'station_%d' % station.number
 
             if station_group_name in cluster_group:

--- a/publicdb/analysissessions/views.py
+++ b/publicdb/analysissessions/views.py
@@ -185,8 +185,8 @@ def confirm_request(request, url):
 
 
 def create_session(request):
-    sessionlist = (SessionRequest.objects.filter(session_confirmed=True)
-                                         .filter(session_pending=True))
+    sessionlist = SessionRequest.objects.filter(session_confirmed=True,
+                                                session_pending=True)
     for sessionrequest in sessionlist:
         sessionrequest.session_confirmed = False
         sessionrequest.save()

--- a/publicdb/histograms/esd.py
+++ b/publicdb/histograms/esd.py
@@ -46,7 +46,7 @@ def search_coincidences_and_store_in_esd(network_summary):
     stations = Station.objects.filter(summary__date=date,
                                       summary__num_events__isnull=False,
                                       summary__needs_update=False,
-                                      pc__is_test=False)
+                                      pc__is_test=False).distinct()
 
     station_numbers = [station.number for station in stations]
     station_groups = ['/hisparc/cluster_%s/station_%d' %

--- a/publicdb/maps/views.py
+++ b/publicdb/maps/views.py
@@ -24,7 +24,8 @@ def station_on_map(request, station_number):
         for station in (Station.objects.select_related('cluster__parent',
                                                        'cluster__country')
                                        .filter(cluster=subcluster,
-                                               pc__is_test=False)):
+                                               pc__is_test=False)
+                                       .distinct()):
             link = station in data_stations
             status = get_station_status(station.number, down, problem, up)
             location = station.latest_location()
@@ -78,7 +79,8 @@ def stations_on_map(request, country=None, cluster=None, subcluster=None):
         for station in (Station.objects.select_related('cluster__parent',
                                                        'cluster__country')
                                        .filter(cluster=subcluster,
-                                               pc__is_test=False)):
+                                               pc__is_test=False)
+                                       .distinct()):
             link = station in data_stations
             status = get_station_status(station.number, down, problem, up)
             location = station.latest_location()

--- a/publicdb/station_layout/forms.py
+++ b/publicdb/station_layout/forms.py
@@ -12,7 +12,7 @@ class StationLayoutQuarantineForm(forms.Form):
     email = forms.EmailField()
 
     station = forms.ModelChoiceField(
-        queryset=Station.objects.filter(pc__is_test=False))
+        queryset=Station.objects.filter(pc__is_test=False).distinct())
     active_date = forms.DateTimeField(
         help_text="Date the detectors were placed in this configuration, "
                   "e.g. '2010-5-17 12:45'.")

--- a/publicdb/status_display/nagios.py
+++ b/publicdb/status_display/nagios.py
@@ -29,7 +29,7 @@ def down_list():
     down = retrieve_station_status(query)
     down_numbers = pc_name_to_station_number(down)
 
-    return set(down_numbers)
+    return down_numbers
 
 
 def problem_list():
@@ -44,7 +44,7 @@ def problem_list():
     problem = retrieve_station_status(query)
     problem_numbers = pc_name_to_station_number(problem)
 
-    return set(problem_numbers)
+    return problem_numbers
 
 
 def up_list():
@@ -57,7 +57,7 @@ def up_list():
     up = retrieve_station_status(query)
     up_numbers = pc_name_to_station_number(up)
 
-    return set(up_numbers)
+    return up_numbers
 
 
 def retrieve_station_status(query):
@@ -88,8 +88,8 @@ def pc_name_to_station_number(shortnames):
     :return: station numbers that have a pc with name in the shortnames.
 
     """
-    stations = list(Station.objects.filter(pc__name__in=shortnames)
-                                   .values_list('number', flat=True))
+    stations = set(Station.objects.filter(pc__name__in=shortnames)
+                                  .values_list('number', flat=True))
     return stations
 
 

--- a/publicdb/status_display/views.py
+++ b/publicdb/status_display/views.py
@@ -160,7 +160,8 @@ def stations_on_map(request, country=None, cluster=None, subcluster=None):
         for station in (Station.objects.select_related('cluster__parent',
                                                        'cluster__country')
                                        .filter(cluster=subcluster,
-                                               pc__is_test=False)):
+                                               pc__is_test=False)
+                                       .distinct()):
 
             link = station in data_stations
             status = get_station_status(station.number, down, problem, up)
@@ -230,10 +231,10 @@ def network_coincidences(request, year=None, month=None, day=None):
 
     n_stations = Station.objects.filter(summary__date=date,
                                         summary__num_events__isnull=False,
-                                        pc__is_test=False).count()
+                                        pc__is_test=False).distinct().count()
     histograms = DailyHistogram.objects.filter(
         source__date=date, source__station__pc__is_test=False,
-        type__slug='eventtime')
+        type__slug='eventtime').distinct()
     number_of_events = sum(sum(histogram.values) for histogram in histograms)
     status = {'station_count': n_stations,
               'n_events': number_of_events}
@@ -616,7 +617,8 @@ def get_eventtime_source(request, station_number, start=None, end=None):
         today = datetime.date.today()
         try:
             last = (Summary.objects.filter(station__number=station_number,
-                                           date__gte=FIRSTDATE, date__lt=today,
+                                           date__gte=FIRSTDATE,
+                                           date__lt=today,
                                            num_events__isnull=False)
                                    .latest().date)
         except Summary.DoesNotExist:
@@ -626,7 +628,8 @@ def get_eventtime_source(request, station_number, start=None, end=None):
         # Get first date with data
         try:
             start = (Summary.objects.filter(station__number=station_number,
-                                            date__gte=FIRSTDATE, date__lt=end,
+                                            date__gte=FIRSTDATE,
+                                            date__lt=end,
                                             num_events__isnull=False)
                                     .earliest().date)
         except Summary.DoesNotExist:


### PR DESCRIPTION
Sometimes Station (or other) objects occurred multiple times in a
QuerySet when they were filtered with a related object of which multiple
could match the query. Using distinct() should solve this.

This should fix the coincidences-with-self for station 9.

After deploy set te update flags for network histograms from december 4 2017, which is when it started: http://data.hisparc.nl/show/network/network/coincidences/2017/12/4/ , until now.
