### PR TITLE
Fix template location in station config

### DIFF
--- a/publicdb/status_display/templates/station_config.html
+++ b/publicdb/status_display/templates/station_config.html
@@ -149,7 +149,7 @@
                 <a href="{% url 'layout:submit' %}">Submit layout</a> |
                 <a href="{% url 'status:source:layout' station.number %}">Source</a>
             </div>
-            {% include "layout_canvas.html" %}
+            {% include "station_layout/canvas.html" %}
             <script>
                 {% if layout.has_four_detectors %}
                     var radius = [{{ layout.detector_1_radius }},


### PR DESCRIPTION
Fixes a line missed in commit eeafdf89649b544df6fd6c7358318cb95f7b3efc
Move station layout templates into subdirectory.

Fixes #223 