### PR TITLE
Determine station status by looking at data, not nagios

### DIFF
--- a/publicdb/status_display/status.py
+++ b/publicdb/status_display/status.py
@@ -22,7 +22,7 @@ class StationStatus(object):
 
         self.stations = Station.objects.values_list('number', flat=True)
         self.stations_with_current_data = Summary.objects.with_data().filter(date__exact=yesterday).values_list('station__number', flat=True)
-        self.stations_with_recent_data = list(Summary.objects.with_data().filter(date__gte=recent_day).values_list('station__number', flat=True))
+        self.stations_with_recent_data = Summary.objects.with_data().filter(date__gte=recent_day).values_list('station__number', flat=True)
         self.stations_with_pc = Pc.objects.exclude(type__slug='admin').filter(is_active=True).values_list('station__number', flat=True)
 
     def get_status(self, station_number):

--- a/publicdb/status_display/status.py
+++ b/publicdb/status_display/status.py
@@ -5,7 +5,6 @@ from publicdb.histograms.models import Summary
 
 
 RECENT_NUM_DAYS = 7
-RECENT_THRESHOLD = 4
 
 
 class StationStatus(object):
@@ -40,7 +39,7 @@ class StationStatus(object):
         """
         if station_number in self.stations_with_current_data:
             return 'up'
-        elif self.stations_with_recent_data.count(station_number) >= RECENT_THRESHOLD:
+        elif station_number in self.stations_with_recent_data:
             return 'problem'
         elif station_number not in self.stations_with_pc:
             return 'unknown'
@@ -50,8 +49,13 @@ class StationStatus(object):
     def get_status_counts(self):
         """Get the status counts for up, problem and down."""
 
-        num_up = [u in self.stations_with_current_data for u in self.stations].count(True)
-        num_problem = [self.stations_with_recent_data.count(u) >= RECENT_THRESHOLD for u in self.stations].count(True)
-        num_down = [self.stations_with_recent_data.count(u) < RECENT_THRESHOLD for u in self.stations].count(True)
+        all_stations = set(self.stations)
+        stations_up = set(self.stations_with_current_data)
+        stations_recent = set(self.stations_with_recent_data)
+        stations_unknown = all_stations.difference(self.stations_with_pc)
+
+        num_up = len(stations_up)
+        num_problem = len(stations_recent.difference(stations_up))
+        num_down = len(all_stations.difference(stations_recent).difference(stations_unknown))
 
         return {'up': num_up, 'problem': num_problem, 'down': num_down}

--- a/publicdb/status_display/status.py
+++ b/publicdb/status_display/status.py
@@ -7,28 +7,37 @@ RECENT_NUM_DAYS = 7
 RECENT_THRESHOLD = 4
 
 
-def get_status_func():
-    """Return function to query the status of a station.
+class StationStatus(object):
 
-    The status can be queried by calling function(station_number). If the
-    station has data as recent as yesterday, it is considered 'up'. If it has
-    at least RECENT_THRESHOLD days of data in the last RECENT_NUM_DAYS, it is
-    considered 'problem'. If it has less data than the threshold, it is
-    considered 'down'.
+    """Query the status of a station.
+
+    You can query the status of a single station, or get the status counts for
+    all stations.
 
     """
-    yesterday = datetime.date.today() - datetime.timedelta(days=1)
-    recent_day = datetime.date.today() - datetime.timedelta(days=RECENT_NUM_DAYS)
 
-    stations_with_current_data = [x.station.number for x in Summary.objects.filter(date__exact=yesterday)]
-    stations_with_recent_data = [x.station.number for x in Summary.objects.filter(date__gte=recent_day)]
+    def __init__(self):
+        yesterday = datetime.date.today() - datetime.timedelta(days=1)
+        recent_day = datetime.date.today() - datetime.timedelta(days=RECENT_NUM_DAYS)
 
-    def get_status(station_number):
-        if station_number in stations_with_current_data:
+        self.stations_with_current_data = [x.station.number for x in Summary.objects.filter(date__exact=yesterday)]
+        self.stations_with_recent_data = [x.station.number for x in Summary.objects.filter(date__gte=recent_day)]
+
+    def get_status(self, station_number):
+        """Query station status.
+
+        If the station has data as recent as yesterday, it is considered 'up'.
+        If it has at least RECENT_THRESHOLD days of data in the last
+        RECENT_NUM_DAYS, it is considered 'problem'. If it has less data than
+        the threshold, it is considered 'down'.
+
+        :param station_number: the station for which to get the statuscount
+        :return: 'up', 'problem', or 'down'
+
+        """
+        if station_number in self.stations_with_current_data:
             return 'up'
-        elif stations_with_recent_data.count(station_number) > RECENT_THRESHOLD:
+        elif self.stations_with_recent_data.count(station_number) > RECENT_THRESHOLD:
             return 'problem'
         else:
             return 'down'
-
-    return get_status

--- a/publicdb/status_display/status.py
+++ b/publicdb/status_display/status.py
@@ -1,8 +1,7 @@
 import datetime
 
-from ..inforecords.models import Station, Pc
 from ..histograms.models import Summary
-
+from ..inforecords.models import Pc, Station
 
 RECENT_NUM_DAYS = 7
 

--- a/publicdb/status_display/status.py
+++ b/publicdb/status_display/status.py
@@ -29,9 +29,9 @@ class StationStatus(object):
         """Query station status.
 
         If the station has data as recent as yesterday, it is considered 'up'.
-        If it has at least RECENT_THRESHOLD days of data in the last
-        RECENT_NUM_DAYS, it is considered 'problem'. If it has less data than
-        the threshold, it is considered 'down'.
+        If it has data in the last RECENT_NUM_DAYS, it is considered 'problem'.
+        If it has no recent data, it is considered 'down', unless it has no
+        active PC registered, then the status is 'unknown'.
 
         :param station_number: the station for which to get the statuscount
         :return: 'up', 'problem', or 'down'
@@ -47,7 +47,14 @@ class StationStatus(object):
             return 'down'
 
     def get_status_counts(self):
-        """Get the status counts for up, problem and down."""
+        """Get the status counts for up, problem and down.
+
+        Count 'up' as all stations with current data. Count 'problem' as all
+        stations with recent data except for stations that are 'up'. Count
+        'down' as all stations without recent data except for stations that
+        have no active PC.
+
+        """
 
         all_stations = set(self.stations)
         stations_up = set(self.stations_with_current_data)

--- a/publicdb/status_display/status.py
+++ b/publicdb/status_display/status.py
@@ -1,0 +1,34 @@
+import datetime
+
+from publicdb.histograms.models import Summary
+
+
+RECENT_NUM_DAYS = 7
+RECENT_THRESHOLD = 4
+
+
+def get_status_func():
+    """Return function to query the status of a station.
+
+    The status can be queried by calling function(station_number). If the
+    station has data as recent as yesterday, it is considered 'up'. If it has
+    at least RECENT_THRESHOLD days of data in the last RECENT_NUM_DAYS, it is
+    considered 'problem'. If it has less data than the threshold, it is
+    considered 'down'.
+
+    """
+    yesterday = datetime.date.today() - datetime.timedelta(days=1)
+    recent_day = datetime.date.today() - datetime.timedelta(days=RECENT_NUM_DAYS)
+
+    stations_with_current_data = [x.station.number for x in Summary.objects.filter(date__exact=yesterday)]
+    stations_with_recent_data = [x.station.number for x in Summary.objects.filter(date__gte=recent_day)]
+
+    def get_status(station_number):
+        if station_number in stations_with_current_data:
+            return 'up'
+        elif stations_with_recent_data.count(station_number) > RECENT_THRESHOLD:
+            return 'problem'
+        else:
+            return 'down'
+
+    return get_status

--- a/publicdb/status_display/status.py
+++ b/publicdb/status_display/status.py
@@ -1,7 +1,7 @@
 import datetime
 
-from publicdb.inforecords.models import Station, Pc
-from publicdb.histograms.models import Summary
+from ..inforecords.models import Station, Pc
+from ..histograms.models import Summary
 
 
 RECENT_NUM_DAYS = 7

--- a/publicdb/status_display/status.py
+++ b/publicdb/status_display/status.py
@@ -21,8 +21,8 @@ class StationStatus(object):
         recent_day = datetime.date.today() - datetime.timedelta(days=RECENT_NUM_DAYS)
 
         self.stations = Station.objects.values_list('number', flat=True)
-        self.stations_with_current_data = Summary.objects.filter(date__exact=yesterday).values_list('station__number', flat=True)
-        self.stations_with_recent_data = list(Summary.objects.filter(date__gte=recent_day).values_list('station__number', flat=True))
+        self.stations_with_current_data = Summary.objects.with_data().filter(date__exact=yesterday).values_list('station__number', flat=True)
+        self.stations_with_recent_data = list(Summary.objects.with_data().filter(date__gte=recent_day).values_list('station__number', flat=True))
         self.stations_with_pc = Pc.objects.exclude(type__slug='admin').filter(is_active=True).values_list('station__number', flat=True)
 
     def get_status(self, station_number):

--- a/publicdb/status_display/status.py
+++ b/publicdb/status_display/status.py
@@ -1,6 +1,6 @@
 import datetime
 
-from publicdb.inforecords.models import Station
+from publicdb.inforecords.models import Station, Pc
 from publicdb.histograms.models import Summary
 
 
@@ -24,6 +24,7 @@ class StationStatus(object):
         self.stations = Station.objects.values_list('number', flat=True)
         self.stations_with_current_data = Summary.objects.filter(date__exact=yesterday).values_list('station__number', flat=True)
         self.stations_with_recent_data = list(Summary.objects.filter(date__gte=recent_day).values_list('station__number', flat=True))
+        self.stations_with_pc = Pc.objects.exclude(type__slug='admin').filter(is_active=True).values_list('station__number', flat=True)
 
     def get_status(self, station_number):
         """Query station status.
@@ -41,6 +42,8 @@ class StationStatus(object):
             return 'up'
         elif self.stations_with_recent_data.count(station_number) >= RECENT_THRESHOLD:
             return 'problem'
+        elif station_number not in self.stations_with_pc:
+            return 'unknown'
         else:
             return 'down'
 

--- a/publicdb/status_display/status.py
+++ b/publicdb/status_display/status.py
@@ -22,8 +22,8 @@ class StationStatus(object):
         recent_day = datetime.date.today() - datetime.timedelta(days=RECENT_NUM_DAYS)
 
         self.stations = Station.objects.values_list('number', flat=True)
-        self.stations_with_current_data = [x.station.number for x in Summary.objects.filter(date__exact=yesterday)]
-        self.stations_with_recent_data = [x.station.number for x in Summary.objects.filter(date__gte=recent_day)]
+        self.stations_with_current_data = Summary.objects.filter(date__exact=yesterday).values_list('station__number', flat=True)
+        self.stations_with_recent_data = list(Summary.objects.filter(date__gte=recent_day).values_list('station__number', flat=True))
 
     def get_status(self, station_number):
         """Query station status.

--- a/publicdb/status_display/views.py
+++ b/publicdb/status_display/views.py
@@ -23,6 +23,8 @@ from ..inforecords.models import Cluster, Country, Pc, Station
 from ..raw_data.date_generator import daterange
 from ..station_layout.models import StationLayout
 from .nagios import get_station_status, get_status_counts, status_lists
+from .status import get_status_func
+
 
 FIRSTDATE = datetime.date(2004, 1, 1)
 MIME_TSV = 'text/tab-separated-values'
@@ -82,13 +84,16 @@ def stations_by_country(request):
 def stations_by_number(request):
     """Show a list of stations, ordered by number"""
 
+    get_status = get_status_func()
+
     data_stations = stations_with_data()
     down, problem, up = status_lists()
     statuscount = get_status_counts(down, problem, up)
     stations = []
     for station in Station.objects.exclude(pc__type__slug='admin'):
         link = station in data_stations
-        status = get_station_status(station.number, down, problem, up)
+        # status = get_station_status(station.number, down, problem, up)
+        status = get_status(station.number)
 
         stations.append({'number': station.number,
                          'name': station.name,

--- a/publicdb/status_display/views.py
+++ b/publicdb/status_display/views.py
@@ -23,7 +23,7 @@ from ..inforecords.models import Cluster, Country, Pc, Station
 from ..raw_data.date_generator import daterange
 from ..station_layout.models import StationLayout
 from .nagios import get_station_status, get_status_counts, status_lists
-from .status import get_status_func
+from .status import StationStatus
 
 
 FIRSTDATE = datetime.date(2004, 1, 1)
@@ -84,7 +84,7 @@ def stations_by_country(request):
 def stations_by_number(request):
     """Show a list of stations, ordered by number"""
 
-    get_status = get_status_func()
+    station_status = StationStatus()
 
     data_stations = stations_with_data()
     down, problem, up = status_lists()
@@ -93,7 +93,7 @@ def stations_by_number(request):
     for station in Station.objects.exclude(pc__type__slug='admin'):
         link = station in data_stations
         # status = get_station_status(station.number, down, problem, up)
-        status = get_status(station.number)
+        status = station_status.get_status(station.number)
 
         stations.append({'number': station.number,
                          'name': station.name,

--- a/publicdb/status_display/views.py
+++ b/publicdb/status_display/views.py
@@ -24,7 +24,6 @@ from ..raw_data.date_generator import daterange
 from ..station_layout.models import StationLayout
 from .status import StationStatus
 
-
 FIRSTDATE = datetime.date(2004, 1, 1)
 MIME_TSV = 'text/tab-separated-values'
 

--- a/publicdb/status_display/views.py
+++ b/publicdb/status_display/views.py
@@ -523,8 +523,8 @@ def station_latest(request, station_number):
                                   station=station)
                           .latest())
 
-    down, problem, up = status_lists()
-    status = get_station_status(station.number, down, problem, up)
+    station_status = StationStatus()
+    status = station_status.get_status(station.number)
 
     date = summary.date
 

--- a/publicdb/status_display/views.py
+++ b/publicdb/status_display/views.py
@@ -88,7 +88,7 @@ def stations_by_number(request):
 
     data_stations = stations_with_data()
     down, problem, up = status_lists()
-    statuscount = get_status_counts(down, problem, up)
+    statuscount = station_status.get_status_counts()
     stations = []
     for station in Station.objects.exclude(pc__type__slug='admin'):
         link = station in data_stations


### PR DESCRIPTION
Since a large part of the VPN network is down due to the certificate issues (early 2018), nagios can't check most stations. Therefore, the stations appear to be down on the data pages, even while a lot of them are still sending data. In this pull request, I switched the status check from nagios to a data-based approach.