### PR TITLE
Enable SELinux on our dev VMs

### DIFF
--- a/packer/CentOS7/http/ks.cfg
+++ b/packer/CentOS7/http/ks.cfg
@@ -6,7 +6,7 @@ network --bootproto=dhcp
 rootpw --iscrypted $1$damlkd,f$UC/u5pUts5QiU3ow.CSso/
 firewall --enabled --service=ssh
 authconfig --enableshadow --passalgo=sha512
-selinux --disabled
+selinux --enforcing
 timezone UTC
 bootloader --location=mbr
 

--- a/packer/CentOS7/template.json
+++ b/packer/CentOS7/template.json
@@ -3,9 +3,10 @@
     {
       "type": "virtualbox-iso",
       "guest_os_type": "RedHat_64",
-      "iso_url": "http://ftp.tudelft.nl/centos.org/7/isos/x86_64/CentOS-7-x86_64-NetInstall-1804.iso",
-      "iso_checksum": "937bf0a7b0932817f84f7230f15ed88911bbbd85c0c958680792b7f8d8f9c1a9",
+      "iso_url": "http://ftp.tudelft.nl/centos.org/7/isos/x86_64/CentOS-7-x86_64-NetInstall-1810.iso",
+      "iso_checksum": "19d94274ef856c4dfcacb2e7cfe4be73e442a71dd65cc3fb6e46db826040b56e",
       "iso_checksum_type": "sha256",
+      "guest_additions_url": "https://download.virtualbox.org/virtualbox/6.0.0/VBoxGuestAdditions_6.0.0.iso",
 
       "disk_size": 10000,
 

--- a/provisioning/roles/common/tasks/main.yml
+++ b/provisioning/roles/common/tasks/main.yml
@@ -52,4 +52,6 @@
       - nmap
       - tcpdump
       - conntrack-tools
+      - setroubleshoot
+      - setools
   become: true


### PR DESCRIPTION
The live servers have SELinux enabled. Enable it for our dev VMs as well.

Install SELinux troubleshooting tools `setroubleshoot`. This enables:

```
sealert -a /var/log/audit/audit.log
```

Which translates the incomprehensible `audit.log` into human readable output (usually with a suggestion how to fix the error)