### PR TITLE
Base status display on events only

### DIFF
--- a/publicdb/histograms/models.py
+++ b/publicdb/histograms/models.py
@@ -55,6 +55,11 @@ class SummaryQuerySet(models.QuerySet):
             models.Q(num_events__isnull=False) |
             models.Q(num_weather__isnull=False))
 
+    def with_events(self):
+        """Filter with at least events"""
+        return self.valid_date().filter(
+            num_events__isnull=False)
+
     def with_config(self):
         """Filter with at least configurations"""
         return self.valid_date().filter(

--- a/publicdb/status_display/status.py
+++ b/publicdb/status_display/status.py
@@ -20,8 +20,8 @@ class StationStatus(object):
         recent_day = datetime.date.today() - datetime.timedelta(days=RECENT_NUM_DAYS)
 
         self.stations = Station.objects.values_list('number', flat=True)
-        self.stations_with_current_data = Summary.objects.with_data().filter(date__exact=yesterday).values_list('station__number', flat=True)
-        self.stations_with_recent_data = Summary.objects.with_data().filter(date__gte=recent_day).values_list('station__number', flat=True)
+        self.stations_with_current_data = Summary.objects.with_events().filter(date__exact=yesterday).values_list('station__number', flat=True)
+        self.stations_with_recent_data = Summary.objects.with_events().filter(date__gte=recent_day).values_list('station__number', flat=True)
         self.stations_with_pc = Pc.objects.exclude(type__slug='admin').filter(is_active=True).values_list('station__number', flat=True)
 
     def get_status(self, station_number):


### PR DESCRIPTION
Add Summary.with_events()
Base status on yesterdays events only.

This fixes the status of stations with only weather data. They should not be
flagged "up".

Fixes last part of #231