### PR TITLE
Add nagios status to data.hisparc.nl homepage (again)

### DIFF
--- a/publicdb/maps/views.py
+++ b/publicdb/maps/views.py
@@ -2,7 +2,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404, render
 
 from ..inforecords.models import Cluster, Country, Station
-from ..status_display.status import StationStatus
+from ..status_display.status import DataStatus
 from ..status_display.views import stations_with_data
 
 
@@ -50,7 +50,7 @@ def stations_on_map(request, country=None, cluster=None, subcluster=None):
 
 def get_subclusters():
     data_stations = stations_with_data()
-    station_status = StationStatus()
+    station_status = DataStatus()
 
     subclusters = []
     for subcluster in Cluster.objects.all():

--- a/publicdb/status_display/static/styles/stations.css
+++ b/publicdb/status_display/static/styles/stations.css
@@ -92,9 +92,8 @@ h1 a:hover {
 
 .statusCube {
     display: inline-block;
-    width: 6px;
+    width: 8px;
     height: 8px;
-    border-radius: 30%;
     background-color: grey;}
 
 .down {background-color: rgba(255, 0, 0, 0.3);}

--- a/publicdb/status_display/static/styles/stations.css
+++ b/publicdb/status_display/static/styles/stations.css
@@ -90,6 +90,13 @@ h1 a:hover {
     border-radius: 50%;
     background-color: grey;}
 
+.statusCube {
+    display: inline-block;
+    width: 6px;
+    height: 8px;
+    border-radius: 30%;
+    background-color: grey;}
+
 .down {background-color: rgba(255, 0, 0, 0.3);}
 .down:hover {background-color: rgba(255, 0, 0, 0.8);}
 

--- a/publicdb/status_display/status.py
+++ b/publicdb/status_display/status.py
@@ -2,6 +2,7 @@ import datetime
 
 from ..histograms.models import Summary
 from ..inforecords.models import Pc, Station
+from .nagios import status_lists
 
 RECENT_NUM_DAYS = 7
 
@@ -65,3 +66,37 @@ class StationStatus(object):
         num_down = len(all_stations.difference(stations_recent).difference(stations_unknown))
 
         return {'up': num_up, 'problem': num_problem, 'down': num_down}
+
+
+class NagiosStatus(object):
+
+    """Query the nagios monitoring status of a station.
+
+    You can query the status of a single station, or get the status counts for
+    all stations.
+
+    """
+
+    def __init__(self):
+        self.down, self.problem, self.up = status_lists()
+
+    def get_status(self, station_number):
+        """Query station status.
+
+        :param station_number: the station for which to get the status
+        :return: 'up', 'problem', or 'down'
+
+        """
+        if station_number in self.up:
+            return 'up'
+        elif station_number in self.problem:
+            return 'problem'
+        elif station_number in self.down:
+            return 'down'
+        else:
+            return 'unknown'
+
+    def get_status_counts(self):
+        """Get the status counts for up, problem and down."""
+
+        return {'up': len(self.up), 'problem': len(self.problem), 'down': len(self.down)}

--- a/publicdb/status_display/status.py
+++ b/publicdb/status_display/status.py
@@ -7,7 +7,7 @@ from .nagios import status_lists
 RECENT_NUM_DAYS = 7
 
 
-class StationStatus(object):
+class DataStatus(object):
 
     """Query the status of a station.
 

--- a/publicdb/status_display/templates/status_display/base_station.html
+++ b/publicdb/status_display/templates/status_display/base_station.html
@@ -32,8 +32,7 @@
 
             <div class="keyvalue"><span class="key">Station</span>
                 <span class="value {% if not has_data %}nolink">Data</span>{% else %}"><a class="{% block current_data %}{% endblock %}" href="{% url 'status:station:summary' station.number %}">Data</a></span>{% endif %}
-                <!--<span class="value"><a class="{% block current_status %}{% endblock %}" href="{% url 'status:station:status' station.number %}">Status</a></span>-->
-                <span class="value nolink" style="color:gray">Status</span>
+                <span class="value"><a class="{% block current_status %}{% endblock %}" href="{% url 'status:station:status' station.number %}">PC Status</a></span>                
                 <span class="value {% if not has_config %}nolink">Config</a></span>{% else %}"><a class="{% block current_config %}{% endblock %}" href="{% url 'status:station:config' station.number %}">Config</a></span>{% endif %}
             </div>
           {% endblock %}

--- a/publicdb/status_display/templates/status_display/base_stations.html
+++ b/publicdb/status_display/templates/status_display/base_stations.html
@@ -42,6 +42,28 @@
 
         <div id="legend">
           {% block legend %}
+            <div class="sectionTitle">Station PC status</div>
+            <div class="keyvalue">
+                <span class='key statusBall up'></span>
+                <span class="value">Up {% if nagios_statuscount %}({{ nagios_statuscount.up }}){% endif %}</span><br>
+            </div>
+            <div class="keyvalue">
+                <span class='key statusBall problem'></span>
+                <span class="value">Problem {% if nagios_statuscount %}({{ nagios_statuscount.problem }}){% endif %}</span><br>
+            </div>
+            <div class="keyvalue">
+                <span class='key statusBall down'></span>
+                <span class="value">Down {% if nagios_statuscount %}({{ nagios_statuscount.down }}){% endif %}</span><br>
+            </div>
+            <div class="keyvalue">
+                <span class='key statusBall unknown'></span>
+                <span class="value">Unknown</span><br>
+            </div>
+            <div class="keyvalue">
+                <span class='key statusBall'></span>
+                <span class="value">&larr; Link to nagios status</span>
+            </div>
+
             <div class="sectionTitle">Data availability</div>
             <div class="keyvalue">
                 <span class="key thin" style='color: #23B;'>Station</span>
@@ -53,26 +75,26 @@
             </div>
 
 
-            <div class="sectionTitle">Current status</div>
+            <div class="sectionTitle">Recent data</div>
             <div class="keyvalue">
-                <span class='key statusBall up'></span>
-                <span class="value">Up {% if statuscount %}({{ statuscount.up }}){% endif %}</span><br>
+                <span class='key statusCube up'></span>
+                <span class="value">Up: Recieved data yesterday {% if statuscount %}({{ statuscount.up }}){% endif %}</span><br>
             </div>
             <div class="keyvalue">
-                <span class='key statusBall problem'></span>
-                <span class="value">Problem {% if statuscount %}({{ statuscount.problem }}){% endif %}</span><br>
+                <span class='key statusCube problem'></span>
+                <span class="value">Problem: No data yesterday {% if statuscount %}({{ statuscount.problem }}){% endif %}</span><br>
             </div>
             <div class="keyvalue">
-                <span class='key statusBall down'></span>
-                <span class="value">Down {% if statuscount %}({{ statuscount.down }}){% endif %}</span><br>
+                <span class='key statusCube down'></span>
+                <span class="value">Down: No recent data {% if statuscount %}({{ statuscount.down }}){% endif %}</span><br>
             </div>
             <div class="keyvalue">
-                <span class='key statusBall unknown'></span>
+                <span class='key statusCube unknown'></span>
                 <span class="value">Unknown</span><br>
             </div>
             <div class="keyvalue">
-                <span class='key statusBall'></span>
-                <span class="value">&larr; Link to status</span>
+                <span class='key statusCube'></span>
+                <span class="value">&larr; Link to most recent data</span>
             </div>
 
             <div class="sectionTitle">Region map</div>

--- a/publicdb/status_display/templates/status_display/stations_by_country.html
+++ b/publicdb/status_display/templates/status_display/stations_by_country.html
@@ -49,12 +49,14 @@
         <ul>
           {% for station in test_stations %}
             <li>
-                <a href="{% url 'status:station:status' station.number %}"><span class='statusBall {{ station.status }}'></span></a>
+                <a href="{% url 'status:station:status' station.number %}"><span class='statusBall {{ station.nagios_status }}'></span></a>
               {% if station.link %}
                 <a href="{% url 'status:station:summary' station.number %}">
+                  <span class='statusCube {{ station.status }}'></span>
                   {{ station.number }} &mdash; {{ station.name }}
                 </a>
               {% else %}
+                  <span class='statusCube {{ station.status }}'></span>
                   {{ station.number }} &mdash; {{ station.name }}
               {% endif %}
             </li>

--- a/publicdb/status_display/templates/status_display/stations_by_country.html
+++ b/publicdb/status_display/templates/status_display/stations_by_country.html
@@ -24,12 +24,14 @@
                     <ul>
                       {% for station in stations %}
                         <li>
-                            <!--<a href="{% url 'status:station:status' station.number %}">--><span class='statusBall {{ station.status }}'></span></a>
+                            <a href="{% url 'status:station:status' station.number %}"><span class='statusBall {{ station.nagios_status }}'></span></a>
                           {% if station.link %}
                             <a href="{% url 'status:station:summary' station.number %}">
+                              <span class='statusCube {{ station.status }}'></span>
                               {{ station.number }} &mdash; {{ station.name }}
                             </a>
                           {% else %}
+                              <span class='statusCube {{ station.status }}'></span>
                               {{ station.number }} &mdash; {{ station.name }}
                           {% endif %}
                         </li>

--- a/publicdb/status_display/templates/status_display/stations_by_name.html
+++ b/publicdb/status_display/templates/status_display/stations_by_name.html
@@ -9,14 +9,18 @@
 {% block list %}
     <ul>
       {% for station in stations %}
-        <li>
-            <!--<a href="{% url 'status:station:status' station.number %}">--><span class='statusBall {{ station.status }}'></span></a>
-          {% if station.link %}
-            <a href="{% url 'status:station:summary' station.number %}">{{ station.name }} ({{ station.number }})</a>
-          {% else %}
-            {{ station.name }} ({{ station.number }})
-          {% endif %}
-        </li>
+      <li>
+          <a href="{% url 'status:station:status' station.number %}"><span class='statusBall {{ station.nagios_status }}'></span></a>
+        {% if station.link %}
+          <a href="{% url 'status:station:summary' station.number %}">
+            <span class='statusCube {{ station.status }}'></span>
+            {{ station.number }} &mdash; {{ station.name }}
+          </a>
+        {% else %}
+            <span class='statusCube {{ station.status }}'></span>
+            {{ station.number }} &mdash; {{ station.name }}
+        {% endif %}
+      </li>
       {% endfor %}
     </ul>
 {% endblock %}

--- a/publicdb/status_display/templates/status_display/stations_by_number.html
+++ b/publicdb/status_display/templates/status_display/stations_by_number.html
@@ -10,11 +10,15 @@
     <ul>
       {% for station in stations %}
         <li>
-            <!--<a href="{% url 'status:station:status' station.number %}">--><span class='statusBall {{ station.status }}'></span></a>
+            <a href="{% url 'status:station:status' station.number %}"><span class='statusBall {{ station.nagios_status }}'></span></a>
           {% if station.link %}
-            <a href="{% url 'status:station:summary' station.number %}">{{ station.number }} &mdash; {{ station.name }}</a>
+            <a href="{% url 'status:station:summary' station.number %}">
+              <span class='statusCube {{ station.status }}'></span>
+              {{ station.number }} &mdash; {{ station.name }}
+            </a>
           {% else %}
-            {{ station.number }} &mdash; {{ station.name }}
+              <span class='statusCube {{ station.status }}'></span>
+              {{ station.number }} &mdash; {{ station.name }}
           {% endif %}
         </li>
       {% endfor %}

--- a/publicdb/status_display/templates/status_display/stations_by_status.html
+++ b/publicdb/status_display/templates/status_display/stations_by_status.html
@@ -13,11 +13,15 @@
       <ul>
         {% for station in stations %}
           <li>
-              <!--<a href="{% url 'status:station:status' station.number %}">--><span class='statusBall {{ station.status }}'></span></a>
+              <a href="{% url 'status:station:status' station.number %}"><span class='statusBall {{ station.nagios_status }}'></span></a>
             {% if station.link %}
-              <a href="{% url 'status:station:summary' station.number %}">{{ station.number }} &mdash; {{ station.name }}</a>
+              <a href="{% url 'status:station:summary' station.number %}">
+                <span class='statusCube {{ station.status }}'></span>
+                {{ station.number }} &mdash; {{ station.name }}
+              </a>
             {% else %}
-              {{ station.number }} &mdash; {{ station.name }}
+                <span class='statusCube {{ station.status }}'></span>
+                {{ station.number }} &mdash; {{ station.name }}
             {% endif %}
           </li>
         {% endfor %}

--- a/publicdb/status_display/views.py
+++ b/publicdb/status_display/views.py
@@ -22,7 +22,7 @@ from ..histograms.models import (Configuration, DailyDataset, DailyHistogram, De
 from ..inforecords.models import Cluster, Country, Pc, Station
 from ..raw_data.date_generator import daterange
 from ..station_layout.models import StationLayout
-from .status import StationStatus, NagiosStatus
+from .status import DataStatus, NagiosStatus
 
 FIRSTDATE = datetime.date(2004, 1, 1)
 MIME_TSV = 'text/tab-separated-values'
@@ -41,7 +41,7 @@ def stations_by_country(request):
     station_nagios_status = NagiosStatus()
     nagios_statuscount = station_nagios_status.get_status_counts()
 
-    station_status = StationStatus()
+    station_status = DataStatus()
     statuscount = station_status.get_status_counts()
 
     data_stations = stations_with_data()
@@ -90,7 +90,7 @@ def stations_by_country(request):
 def stations_by_number(request):
     """Show a list of stations, ordered by number"""
 
-    station_status = StationStatus()
+    station_status = DataStatus()
     statuscount = station_status.get_status_counts()
 
     data_stations = stations_with_data()
@@ -111,7 +111,7 @@ def stations_by_number(request):
 def stations_by_status(request):
     """Show a list of stations, ordered by status"""
 
-    station_status = StationStatus()
+    station_status = DataStatus()
     statuscount = station_status.get_status_counts()
 
     data_stations = stations_with_data()
@@ -135,7 +135,7 @@ def stations_by_status(request):
 def stations_by_name(request):
     """Show a list of stations, ordered by station name"""
 
-    station_status = StationStatus()
+    station_status = DataStatus()
     statuscount = station_status.get_status_counts()
 
     data_stations = stations_with_data()
@@ -176,7 +176,7 @@ def stations_on_map(request, country=None, cluster=None, subcluster=None):
                     focus = [get_object_or_404(cluster.subclusters, name=subcluster).name]
 
     data_stations = stations_with_data()
-    station_status = StationStatus()
+    station_status = DataStatus()
     statuscount = station_status.get_status_counts()
 
     subclusters = []
@@ -611,7 +611,7 @@ def station_latest(request, station_number):
                                   station=station)
                           .latest())
 
-    station_status = StationStatus()
+    station_status = DataStatus()
     status = station_status.get_status(station.number)
 
     date = summary.date

--- a/publicdb/status_display/views.py
+++ b/publicdb/status_display/views.py
@@ -83,7 +83,8 @@ def stations_by_country(request):
     return render(request, 'status_display/stations_by_country.html',
                   {'countries': countries,
                    'test_stations': test_stations,
-                   'statuscount': statuscount})
+                   'statuscount': statuscount,
+                   'nagios_statuscount': nagios_statuscount})
 
 
 def stations_by_number(request):

--- a/publicdb/status_display/views.py
+++ b/publicdb/status_display/views.py
@@ -203,7 +203,6 @@ def stations_on_map(request, country=None, cluster=None, subcluster=None):
         for station in subcluster.stations.filter(pcs__is_test=False).distinct():
             link = station in data_stations
             status = station_status.get_status(station.number)
-            nagios_status = nagios_station_status.get_status(station.number)
 
             location = station.latest_location()
             station_data = {'number': station.number,

--- a/publicdb/status_display/views.py
+++ b/publicdb/status_display/views.py
@@ -22,7 +22,7 @@ from ..histograms.models import (Configuration, DailyDataset, DailyHistogram, De
 from ..inforecords.models import Cluster, Country, Pc, Station
 from ..raw_data.date_generator import daterange
 from ..station_layout.models import StationLayout
-from .status import StationStatus
+from .status import StationStatus, NagiosStatus
 
 FIRSTDATE = datetime.date(2004, 1, 1)
 MIME_TSV = 'text/tab-separated-values'
@@ -37,6 +37,10 @@ def stations(request):
 def stations_by_country(request):
     """Show a list of stations, ordered by country, cluster and subcluster"""
 
+
+    station_nagios_status = NagiosStatus()
+    nagios_statuscount = station_nagios_status.get_status_counts()
+
     station_status = StationStatus()
     statuscount = station_status.get_status_counts()
 
@@ -50,11 +54,13 @@ def stations_by_country(request):
                            .select_related('cluster__country', 'cluster__parent')):
         link = station in data_stations
         status = station_status.get_status(station.number)
+        nagios_status = station_nagios_status.get_status(station.number)
 
         station_info = {'number': station.number,
                         'name': station.name,
                         'link': link,
-                        'status': status}
+                        'status': status,
+                        'nagios_status': nagios_status}
 
         country = station.cluster.country.name
         if station.cluster.parent:


### PR DESCRIPTION
@vaneijk @renaldo20 

This add the (nagios) station PC status balls to (again) [data.hisparc.nl](https://data.hisparc.nl):

![image](https://user-images.githubusercontent.com/6316468/54105313-ed017680-43d2-11e9-8774-1821241ba345.png)

status ball/circle -> nagios (to be consistent with infopakket docs)
status box -> "new" station status based on recent data.

This is inconsitent with the station map, where a circle is used to represent status based on data.