### PR TITLE
Fix mail from pique

### DIFF
--- a/provisioning/roles/publicdb/templates/settings.py
+++ b/provisioning/roles/publicdb/templates/settings.py
@@ -11,10 +11,11 @@ DEBUG = {{ debug }}
 ADMINS = (
     ('Kasper van Dam', 'kaspervd@nikhef.nl'),
     ('Arne de Laat', 'arne@delaat.net'),
+    ('Tom Kooij', 'tkooij@nikhef.nl'),
 )
 MANAGERS = ADMINS
 
-SERVER_EMAIL = 'info@hisparc.nl'
+SERVER_EMAIL = 'Beheer HiSPARC <bhrhispa@nikhef.nl>'
 
 DATABASES = {
     'default': {

--- a/publicdb/analysissessions/models.py
+++ b/publicdb/analysissessions/models.py
@@ -212,7 +212,7 @@ class SessionRequest(models.Model):
             Greetings,
             The HiSPARC Team''' %
             (self.name, self.url))
-        sender = 'info@hisparc.nl'
+        sender = 'Beheer HiSPARC <bhrhispa@nikhef.nl>'
         send_mail(subject, message, sender, [self.email], fail_silently=False)
         self.mail_send = True
         self.save()
@@ -237,7 +237,7 @@ class SessionRequest(models.Model):
             Greetings,
             The HiSPARC Team''' %
             (self.name, self.sid, self.pin, self.events_created, slugify(self.sid)))
-        sender = 'info@hisparc.nl'
+        sender = 'Beheer HiSPARC <bhrhispa@nikhef.nl>'
         send_mail(subject, message, sender, [self.email], fail_silently=False)
 
     def sendmail_created_less(self):
@@ -262,7 +262,7 @@ class SessionRequest(models.Model):
             Greetings,
             The HiSPARC Team''' %
             (self.name, self.sid, self.pin, self.events_created, slugify(self.sid)))
-        sender = 'info@hisparc.nl'
+        sender = 'Beheer HiSPARC <bhrhispa@nikhef.nl>'
         send_mail(subject, message, sender, [self.email], fail_silently=False)
 
     def sendmail_zero(self):
@@ -278,5 +278,5 @@ class SessionRequest(models.Model):
             Greetings,
             The HiSPARC Team''' %
             self.name)
-        sender = 'info@hisparc.nl'
+        sender = 'Beheer HiSPARC <bhrhispa@nikhef.nl>'
         send_mail(subject, message, sender, [self.email], fail_silently=False)

--- a/publicdb/station_layout/models.py
+++ b/publicdb/station_layout/models.py
@@ -119,7 +119,7 @@ class StationLayoutQuarantine(models.Model):
             Greetings,
             The HiSPARC Team''' %
             (self.name, self.station, self.hash_submit))
-        sender = 'info@hisparc.nl'
+        sender = 'Beheer HiSPARC <bhrhispa@nikhef.nl>'
         send_mail(subject, message, sender, [self.email], fail_silently=False)
 
     def sendmail_review(self):
@@ -138,7 +138,7 @@ class StationLayoutQuarantine(models.Model):
             Greetings,
             The HiSPARC Team''' %
             (self.station, self.hash_review))
-        sender = 'info@hisparc.nl'
+        sender = 'Beheer HiSPARC <bhrhispa@nikhef.nl>'
         send_mail(subject, message, sender, ['beheer@hisparc.nl'],
                   fail_silently=False)
 
@@ -154,7 +154,7 @@ class StationLayoutQuarantine(models.Model):
             Greetings,
             The HiSPARC Team''' %
             (self.name, self.station))
-        sender = 'info@hisparc.nl'
+        sender = 'Beheer HiSPARC <bhrhispa@nikhef.nl>'
         send_mail(subject, message, sender, [self.email], fail_silently=False)
 
     def sendmail_declined(self):
@@ -169,5 +169,5 @@ class StationLayoutQuarantine(models.Model):
             Greetings,
             The HiSPARC Team''' %
             (self.name, self.station))
-        sender = 'info@hisparc.nl'
+        sender = 'Beheer HiSPARC <bhrhispa@nikhef.nl>'
         send_mail(subject, message, sender, [self.email], fail_silently=False)


### PR DESCRIPTION
smtp.nikhef.nl will only accept messages with From: bhrhispa@nikhef.nl
for relay outside the nikhef domain.

Add Tom Kooij as admin (mail recipient) for data.hisparc.nl

Fixes #241