### PR TITLE
Add vpn and datastore containers with xmlrpc servers.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,26 @@ services:
     tty: true
     depends_on:
       - postgres
+
+  vpn:
+    image: 'python:2.7-alpine'
+    restart: unless-stopped
+    volumes:
+      - './scripts:/base:ro'
     ports:
-      - '8000:8000'
+      - '8001:8001'
+    working_dir: '/base'
+    command: 'python fake-vpn-xmlrpc-server.py'
+
+  datastore:
+    image: 'python:2.7-alpine'
+    restart: unless-stopped
+    volumes:
+      - './scripts:/base:ro'
+    ports:
+      - '8002:8002'
+    working_dir: '/base'
+    command: 'python fake-datastore-xmlrpc-server.py'
 
 volumes:
   pgdata:

--- a/publicdb/settings_docker.py
+++ b/publicdb/settings_docker.py
@@ -13,6 +13,10 @@ DATABASES = {
     }
 }
 
+# VPN and datastore XML-RPC Proxies
+VPN_PROXY = 'http://vpn:8001'
+DATASTORE_PROXY = 'http://datastore:8002'
+
 SESSION_COOKIE_SECURE = False
 CSRF_COOKIE_SECURE = False
 SECURE_SSL_REDIRECT = False

--- a/scripts/fake-datastore-xmlrpc-server.py
+++ b/scripts/fake-datastore-xmlrpc-server.py
@@ -16,7 +16,7 @@ import hashlib
 
 HASH = '/tmp/hash_datastore'
 DATASTORE_CFG = '/tmp/station_list.csv'
-CFG_URL = 'http://localhost:8003/config/datastore'
+CFG_URL = 'http://publicdb:8000/config/datastore'
 
 
 def reload_datastore():


### PR DESCRIPTION
I tried adding containers to simulate the xmlrpc servers.
However, it does not seems to work as expected yet.

Can be tested using the `examples/vpn-xmlrpc-client.py` you may need to change the ServerProxy address if you run it from within a containers, i.e. make it http://vpn:8001 when running from within the publicdb container.