### PR TITLE
Provisioning: Add PATH to hisparc crontab

### DIFF
--- a/provisioning/roles/letsencrypt/tasks/main.yml
+++ b/provisioning/roles/letsencrypt/tasks/main.yml
@@ -22,6 +22,15 @@
   notify: restart nginx
   become: true
 
+# fix path for certbot to work (github issue gh-277)
+- name: Set PATH on top of crontab
+  cron:
+    name: PATH
+    cron_file: hisparc
+    env: yes
+    job: "/opt/miniconda/bin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin"
+  become: true
+
 - name: enable cron job for certificate renewal
   cron:
     name: "certbot renew twice a day"


### PR DESCRIPTION
PATH in hisparc crontab (/etc/cron.d/hisparc) is needed for certbot
to work.
Fixes gh-277