### PR TITLE
Add extra non-blocking logging to ESD updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ ignore = [
 'publicdb/settings_docker.py' = ['F405']  # Star imports
 # FIXME: The following should be fixable
 'publicdb/inforecords/models.py' = ['S110', 'BLE001']  # Capture specific exceptions and handle it
+'publicdb/histograms/jobs.py' = ['BLE001']  # Capture specific exceptions and handle it
 
 [tool.ruff.lint.isort]
 lines-between-types = 1


### PR DESCRIPTION
Return None instead of summary indicating flags should not be updated.
Remove temporary files which wont be used.

This does mean the update job will retry it every day, but at least it should not block other summaries from finishing. And also provide more useful information in Sentry when it fails.