### PR TITLE
Fix dataset plots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test: coveragetests linttest doctest ansibletest
 
 .PHONY: unittests
 unittests:
-	coverage run ./manage.py test --shuffle $(tests)
+	coverage run ./manage.py test $(tests) --shuffle
 
 .PHONY: coveragetests
 coveragetests: unittests

--- a/publicdb/status_display/templatetags/fix_data.py
+++ b/publicdb/status_display/templatetags/fix_data.py
@@ -42,7 +42,7 @@ def fix_timestamps_in_data(values):
 
     x, y = list(zip(*values))
     seconds_in_day = [timestamp % 86400 for timestamp in x]
-    hours_in_day = [seconds // 3600.0 for seconds in seconds_in_day]
+    hours_in_day = [seconds / 3600.0 for seconds in seconds_in_day]
     values = [list(u) for u in zip(hours_in_day, y)]
 
     return values

--- a/tests/test_status_display/test_templatetags/test_fix_data.py
+++ b/tests/test_status_display/test_templatetags/test_fix_data.py
@@ -1,0 +1,49 @@
+from django.test import TestCase
+
+from publicdb.status_display.templatetags import fix_data
+
+
+class TestFixData(TestCase):
+    def test_fix_histogram_data(self):
+        self.assertEqual([[1, 2.1], [2, 2.2], [3, 2.2]], fix_data.fix_histogram_data([[1, 2.1], [2, 2.2]]))
+        self.assertEqual([[1, 2.1], [10, 2.2], [19, 2.2]], fix_data.fix_histogram_data([[1, 2.1], [10, 2.2]]))
+
+    def test_fix_timestamps(self):
+        self.assertEqual([[1_000, 2.1], [2_000, 2.2]], fix_data.fix_timestamps([[1, 2.1], [2, 2.2]]))
+
+    def test_fix_timestamps_in_data(self):
+        dataset = [
+            [1647993600, 98],
+            [1647993780, 99],
+            [1648079820, 1],
+        ]
+        self.assertEqual(
+            [[0, 98], [0.05, 99], [23.95, 1]],
+            fix_data.fix_timestamps_in_data(dataset),
+        )
+
+    def test_slice_data(self):
+        result = fix_data.slice_data([1] * 2_000, 200)
+        self.assertEqual(10, len(result))
+        self.assertEqual([1] * 10, result)
+
+    def test_round_data(self):
+        self.assertEqual([[1, 2]], fix_data.round_data([[1, 2.11]], 0))
+        self.assertEqual([[1, 2.1]], fix_data.round_data([[1, 2.11]], 1))
+        self.assertEqual([[2.0, 2.2]], fix_data.round_data([[1.99, 2.16]], 1))
+
+    def test_shift_bins(self):
+        self.assertEqual([[2, 2.1], [3, 2.2]], fix_data.shift_bins([[1, 2.1], [2, 2.2]], 1))
+
+    def test_none_to_nan(self):
+        self.assertEqual('nan', fix_data.none_to_nan(None))
+
+        for value in [0., 0, 1, '', 'this']:
+            self.assertEqual(value, fix_data.none_to_nan(value))
+
+    def test_mv_to_adc(self):
+        self.assertEqual(30, fix_data.mv_to_adc(30))
+        self.assertEqual(30, fix_data.mv_to_adc(30.))
+        self.assertEqual(30.7, fix_data.mv_to_adc(30.7))
+        self.assertEqual(323, fix_data.mv_to_adc(-70))
+        self.assertEqual(253, fix_data.mv_to_adc(-30))

--- a/tests/test_status_display/test_templatetags/test_fix_strings.py
+++ b/tests/test_status_display/test_templatetags/test_fix_strings.py
@@ -1,0 +1,12 @@
+from django.test import TestCase
+
+from publicdb.status_display.templatetags import fix_strings
+
+
+class TestFixStrings(TestCase):
+    def test_remove_hyphens(self):
+        self.assertEqual('', fix_strings.remove_hyphens(''))
+        self.assertEqual('', fix_strings.remove_hyphens('-'))
+        self.assertEqual('', fix_strings.remove_hyphens('--'))
+        self.assertEqual('WithoutHyphens', fix_strings.remove_hyphens('-Without-Hyphens'))
+


### PR DESCRIPTION
This fixes the conversion of timestamps to hour of day by not rounding the values (using integer division).
Also add tests to most templatetags.

Also fix unittest make target when specifying specific tests to prevent it being seen as a SEED for shuffle.


Examples

Barometer:
<img width="616" alt="baro_current" src="https://github.com/user-attachments/assets/eeccf311-2860-47e9-a05b-965b76c3e57a">
<img width="615" alt="baro_fixed" src="https://github.com/user-attachments/assets/97dcebd8-2592-40d5-9eba-ab51f25e9333">

Singles:
<img width="620" alt="singles_current" src="https://github.com/user-attachments/assets/2465d062-33f4-4506-aa5e-514c4758c9e7">
<img width="614" alt="singles_fixed" src="https://github.com/user-attachments/assets/d07b20dc-d92e-4523-b90b-154f70ddb16e">
