### PR TITLE
Fix hex encoding a byte string

### DIFF
--- a/publicdb/station_layout/models.py
+++ b/publicdb/station_layout/models.py
@@ -95,8 +95,8 @@ class StationLayoutQuarantine(models.Model):
         verbose_name_plural = 'Station layouts quarantine'
 
     def generate_hashes(self):
-        hash_submit = os.urandom(16).encode('hex')
-        hash_review = os.urandom(16).encode('hex')
+        hash_submit = os.urandom(16).hex()
+        hash_review = os.urandom(16).hex()
         if StationLayoutQuarantine.objects.filter(hash_submit=hash_submit) or StationLayoutQuarantine.objects.filter(
             hash_review=hash_review,
         ):


### PR DESCRIPTION
Old code lead to:
AttributeError: 'bytes' object has no attribute 'encode'.